### PR TITLE
Fix bug that tagName can contain trailing newline

### DIFF
--- a/dist/psvg.global.js
+++ b/dist/psvg.global.js
@@ -37,7 +37,7 @@ var PSVG = (() => {
           let lvl = 0;
           function parseElement() {
             function getTagName(open) {
-              return open.trim().split(" ")[0];
+              return open.trim().split(" ")[0].trimEnd();
             }
             function getAttributes(open) {
               let thing1 = open.split(" ").slice(1).join(" ");

--- a/dist/psvg.js
+++ b/dist/psvg.js
@@ -12,7 +12,7 @@ function parsePSVG(str) {
       let lvl = 0;
       function parseElement() {
         function getTagName(open) {
-          return open.trim().split(" ")[0];
+          return open.trim().split(" ")[0].trimEnd();
         }
         function getAttributes(open) {
           let thing1 = open.split(" ").slice(1).join(" ");

--- a/dist/psvg.mjs
+++ b/dist/psvg.mjs
@@ -12,7 +12,7 @@ function parsePSVG(str) {
       let lvl = 0;
       function parseElement() {
         function getTagName(open) {
-          return open.trim().split(" ")[0];
+          return open.trim().split(" ")[0].trimEnd();
         }
         function getAttributes(open) {
           let thing1 = open.split(" ").slice(1).join(" ");

--- a/psvg.ts
+++ b/psvg.ts
@@ -22,7 +22,7 @@ export function parsePSVG(str:string) : PSVGElement[] {
       let lvl = 0;
       function parseElement():void{
         function getTagName(open:string){
-          return open.trim().split(" ")[0];
+          return open.trim().split(" ")[0].trimEnd();
         }
         function getAttributes(open:string){
           // oneliner doesn't work for safari:


### PR DESCRIPTION
As shown below, if the `parsePSVG` function is passed argument that includes a newline after the tag name, the `PSVGElement` object's `tagName` property will contain the string with the trailing newline left in it.

```javascript
import { parsePSVG } from '@lingdong/psvg';

const src = `
    <psvg width="500" height="200">
        <circle
            cx="50"
            cy="50"
            r="15"/>
    </psvg>`;

const parseResult = parsePSVG(src);

console.log(parseResult[0].children[0].tagName === 'circle\n'); // true
```

To fix this bug, I added `String.prototype.trimEnd` method call in the `getTagName` function.