### PR TITLE
Introduce ESLint, typescript-eslint and Prettier

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,19 +4,16 @@ module.exports = {
     es2021: true,
     node: true,
   },
-  extends: [
-    'eslint:recommended',
-  ],
+  extends: ['eslint:recommended', 'plugin:prettier/recommended'],
   ignorePatterns: ['dist'],
   overrides: [
     {
       files: ['**/*.ts'],
       extends: [
         'plugin:@typescript-eslint/recommended',
+        'prettier/@typescript-eslint',
       ],
-      plugins: [
-        '@typescript-eslint',
-      ],
+      plugins: ['@typescript-eslint'],
       parser: '@typescript-eslint/parser',
       parserOptions: {
         ecmaVersion: 12,
@@ -25,4 +22,4 @@ module.exports = {
       },
     },
   ],
-}
+};

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,28 @@
+module.exports = {
+  env: {
+    browser: true,
+    es2021: true,
+    node: true,
+  },
+  extends: [
+    'eslint:recommended',
+  ],
+  ignorePatterns: ['dist'],
+  overrides: [
+    {
+      files: ['**/*.ts'],
+      extends: [
+        'plugin:@typescript-eslint/recommended',
+      ],
+      plugins: [
+        '@typescript-eslint',
+      ],
+      parser: '@typescript-eslint/parser',
+      parserOptions: {
+        ecmaVersion: 12,
+        sourceType: 'module',
+        project: './tsconfig.json',
+      },
+    },
+  ],
+}

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  singleQuote: true,
+  tabWidth: 2,
+  trailingComma: 'es5',
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -540,6 +540,15 @@
         "get-stdin": "^6.0.0"
       }
     },
+    "eslint-plugin-prettier": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.4.tgz",
+      "integrity": "sha512-jZDa8z76klRqo+TdGDTFJSavwbnWK2ZpqGKNZ+VvweMW516pDUMmQ2koXvxEE4JhzNvTv+radye/bWGBmA6jmg==",
+      "dev": true,
+      "requires": {
+        "prettier-linter-helpers": "^1.0.0"
+      }
+    },
     "eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -648,6 +657,12 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "fast-diff": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
       "dev": true
     },
     "fast-glob": {
@@ -1109,6 +1124,15 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.0.tgz",
       "integrity": "sha512-yYerpkvseM4iKD/BXLYUkQV5aKt4tQPqaGW6EsZjzyu0r7sVZZNPJW4Y8MyKmicp6t42XUPcBVA+H6sB3gqndw==",
       "dev": true
+    },
+    "prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "requires": {
+        "fast-diff": "^1.1.2"
+      }
     },
     "progress": {
       "version": "2.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -140,6 +140,60 @@
       "integrity": "sha512-z/5Yd59dCKI5kbxauAJgw6dLPzW+TNOItNE00PkpzNwUIEwdj/Lsqwq94H5DdYBX7C13aRA0CY32BK76+neEUA==",
       "dev": true
     },
+    "@typescript-eslint/parser": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.8.1.tgz",
+      "integrity": "sha512-QND8XSVetATHK9y2Ltc/XBl5Ro7Y62YuZKnPEwnNPB8E379fDsvzJ1dMJ46fg/VOmk0hXhatc+GXs5MaXuL5Uw==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/scope-manager": "4.8.1",
+        "@typescript-eslint/types": "4.8.1",
+        "@typescript-eslint/typescript-estree": "4.8.1",
+        "debug": "^4.1.1"
+      }
+    },
+    "@typescript-eslint/scope-manager": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.8.1.tgz",
+      "integrity": "sha512-r0iUOc41KFFbZdPAdCS4K1mXivnSZqXS5D9oW+iykQsRlTbQRfuFRSW20xKDdYiaCoH+SkSLeIF484g3kWzwOQ==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "4.8.1",
+        "@typescript-eslint/visitor-keys": "4.8.1"
+      }
+    },
+    "@typescript-eslint/types": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.8.1.tgz",
+      "integrity": "sha512-ave2a18x2Y25q5K05K/U3JQIe2Av4+TNi/2YuzyaXLAsDx6UZkz1boZ7nR/N6Wwae2PpudTZmHFXqu7faXfHmA==",
+      "dev": true
+    },
+    "@typescript-eslint/typescript-estree": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.8.1.tgz",
+      "integrity": "sha512-bJ6Fn/6tW2g7WIkCWh3QRlaSU7CdUUK52shx36/J7T5oTQzANvi6raoTsbwGM11+7eBbeem8hCCKbyvAc0X3sQ==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "4.8.1",
+        "@typescript-eslint/visitor-keys": "4.8.1",
+        "debug": "^4.1.1",
+        "globby": "^11.0.1",
+        "is-glob": "^4.0.1",
+        "lodash": "^4.17.15",
+        "semver": "^7.3.2",
+        "tsutils": "^3.17.1"
+      }
+    },
+    "@typescript-eslint/visitor-keys": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.8.1.tgz",
+      "integrity": "sha512-3nrwXFdEYALQh/zW8rFwP4QltqsanCDz4CwWMPiIZmwlk9GlvBeueEIbq05SEq4ganqM0g9nh02xXgv5XI3PeQ==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "4.8.1",
+        "eslint-visitor-keys": "^2.0.0"
+      }
+    },
     "acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
@@ -1259,6 +1313,12 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true
     },
+    "tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
     "tsup": {
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/tsup/-/tsup-3.8.0.tgz",
@@ -1275,6 +1335,15 @@
         "rollup": "^2.33.1",
         "rollup-plugin-dts": "^1.4.10",
         "sucrase": "^3.16.0"
+      }
+    },
+    "tsutils": {
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.17.1.tgz",
+      "integrity": "sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.8.1"
       }
     },
     "type-check": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -134,11 +134,46 @@
         "fastq": "^1.6.0"
       }
     },
+    "@types/json-schema": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.6.tgz",
+      "integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==",
+      "dev": true
+    },
     "@types/node": {
       "version": "14.14.8",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.8.tgz",
       "integrity": "sha512-z/5Yd59dCKI5kbxauAJgw6dLPzW+TNOItNE00PkpzNwUIEwdj/Lsqwq94H5DdYBX7C13aRA0CY32BK76+neEUA==",
       "dev": true
+    },
+    "@typescript-eslint/eslint-plugin": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.8.1.tgz",
+      "integrity": "sha512-d7LeQ7dbUrIv5YVFNzGgaW3IQKMmnmKFneRWagRlGYOSfLJVaRbj/FrBNOBC1a3tVO+TgNq1GbHvRtg1kwL0FQ==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/experimental-utils": "4.8.1",
+        "@typescript-eslint/scope-manager": "4.8.1",
+        "debug": "^4.1.1",
+        "functional-red-black-tree": "^1.0.1",
+        "regexpp": "^3.0.0",
+        "semver": "^7.3.2",
+        "tsutils": "^3.17.1"
+      }
+    },
+    "@typescript-eslint/experimental-utils": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.8.1.tgz",
+      "integrity": "sha512-WigyLn144R3+lGATXW4nNcDJ9JlTkG8YdBWHkDlN0lC3gUGtDi7Pe3h5GPvFKMcRz8KbZpm9FJV9NTW8CpRHpg==",
+      "dev": true,
+      "requires": {
+        "@types/json-schema": "^7.0.3",
+        "@typescript-eslint/scope-manager": "4.8.1",
+        "@typescript-eslint/types": "4.8.1",
+        "@typescript-eslint/typescript-estree": "4.8.1",
+        "eslint-scope": "^5.0.0",
+        "eslint-utils": "^2.0.0"
+      }
     },
     "@typescript-eslint/parser": {
       "version": "4.8.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -531,6 +531,15 @@
         }
       }
     },
+    "eslint-config-prettier": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.15.0.tgz",
+      "integrity": "sha512-a1+kOYLR8wMGustcgAjdydMsQ2A/2ipRPwRKUmfYaSxc9ZPcrku080Ctl6zrZzZNs/U82MjSv+qKREkoq3bJaw==",
+      "dev": true,
+      "requires": {
+        "get-stdin": "^6.0.0"
+      }
+    },
     "eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -739,6 +748,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
+    "get-stdin": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+      "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
       "dev": true
     },
     "glob": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1089,6 +1089,12 @@
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true
     },
+    "prettier": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.0.tgz",
+      "integrity": "sha512-yYerpkvseM4iKD/BXLYUkQV5aKt4tQPqaGW6EsZjzyu0r7sVZZNPJW4Y8MyKmicp6t42XUPcBVA+H6sB3gqndw==",
+      "dev": true
+    },
     "progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
       "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
       "dev": true,
-      "optional": true,
       "requires": {
         "@babel/highlight": "^7.10.4"
       }
@@ -18,15 +17,13 @@
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
       "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "@babel/highlight": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
       "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
       "dev": true,
-      "optional": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.10.4",
         "chalk": "^2.0.0",
@@ -38,7 +35,6 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "color-convert": "^1.9.0"
           }
@@ -48,7 +44,6 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
@@ -60,7 +55,6 @@
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
           "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
           "dev": true,
-          "optional": true,
           "requires": {
             "color-name": "1.1.3"
           }
@@ -69,25 +63,48 @@
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
           "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
           "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "supports-color": {
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
-          "optional": true,
           "requires": {
             "has-flag": "^3.0.0"
           }
+        }
+      }
+    },
+    "@eslint/eslintrc": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.2.1.tgz",
+      "integrity": "sha512-XRUeBZ5zBWLYgSANMpThFddrZZkEbGHgUdt5UJjZfnlN9BGCiUBrf+nvbRupSjMvqzwnQN0qwCmOxITt1cfywA==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.12.4",
+        "debug": "^4.1.1",
+        "espree": "^7.3.0",
+        "globals": "^12.1.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^3.13.1",
+        "lodash": "^4.17.19",
+        "minimatch": "^3.0.4",
+        "strip-json-comments": "^3.1.1"
+      },
+      "dependencies": {
+        "ignore": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+          "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+          "dev": true
         }
       }
     },
@@ -123,6 +140,42 @@
       "integrity": "sha512-z/5Yd59dCKI5kbxauAJgw6dLPzW+TNOItNE00PkpzNwUIEwdj/Lsqwq94H5DdYBX7C13aRA0CY32BK76+neEUA==",
       "dev": true
     },
+    "acorn": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+      "dev": true
+    },
+    "acorn-jsx": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
+      "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
+      "dev": true
+    },
+    "ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "ansi-colors": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "dev": true
+    },
     "ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -148,10 +201,25 @@
         "picomatch": "^2.0.4"
       }
     },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
     "array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true
+    },
+    "astral-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
     "balanced-match": {
@@ -189,6 +257,12 @@
       "version": "6.6.1",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.6.1.tgz",
       "integrity": "sha512-uhki4T3Ax68hw7Dufi0bATVAF8ayBSwOKUEJHjObPrUN4tlQ8Lf7oljpTje/mArLxYN0D743c2zJt4C1bVTCqg==",
+      "dev": true
+    },
+    "callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true
     },
     "chalk": {
@@ -244,6 +318,32 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
+    "cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
+      "requires": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      }
+    },
+    "debug": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "dev": true,
+      "requires": {
+        "ms": "2.1.2"
+      }
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
     "dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -251,6 +351,30 @@
       "dev": true,
       "requires": {
         "path-type": "^4.0.0"
+      }
+    },
+    "doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2"
+      }
+    },
+    "emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "dev": true
+    },
+    "enquirer": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
+      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "^4.1.1"
       }
     },
     "esbuild": {
@@ -263,8 +387,170 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "eslint": {
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.14.0.tgz",
+      "integrity": "sha512-5YubdnPXrlrYAFCKybPuHIAH++PINe1pmKNc5wQRB9HSbqIK1ywAnntE3Wwua4giKu0bjligf1gLF6qxMGOYRA==",
       "dev": true,
-      "optional": true
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@eslint/eslintrc": "^0.2.1",
+        "ajv": "^6.10.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.0.1",
+        "doctrine": "^3.0.0",
+        "enquirer": "^2.3.5",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^2.1.0",
+        "eslint-visitor-keys": "^2.0.0",
+        "espree": "^7.3.0",
+        "esquery": "^1.2.0",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^5.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "glob-parent": "^5.0.0",
+        "globals": "^12.1.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^3.13.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash": "^4.17.19",
+        "minimatch": "^3.0.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.1",
+        "progress": "^2.0.0",
+        "regexpp": "^3.1.0",
+        "semver": "^7.2.1",
+        "strip-ansi": "^6.0.0",
+        "strip-json-comments": "^3.1.0",
+        "table": "^5.2.3",
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
+      },
+      "dependencies": {
+        "ignore": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+          "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      }
+    },
+    "eslint-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.1.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-visitor-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz",
+      "integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
+      "dev": true
+    },
+    "espree": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.0.tgz",
+      "integrity": "sha512-dksIWsvKCixn1yrEXO8UosNSxaDoSYpq9reEjZSbHLpT5hpaCAKTLBwq0RHtLrIr+c0ByiYzWT8KTMRzoRCNlw==",
+      "dev": true,
+      "requires": {
+        "acorn": "^7.4.0",
+        "acorn-jsx": "^5.2.0",
+        "eslint-visitor-keys": "^1.3.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
+        }
+      }
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
+    },
+    "esquery": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.3.1.tgz",
+      "integrity": "sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^5.1.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+          "dev": true
+        }
+      }
+    },
+    "esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^5.2.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+          "dev": true
+        }
+      }
+    },
+    "estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true
+    },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
     },
     "fast-glob": {
       "version": "3.2.4",
@@ -280,6 +566,18 @@
         "picomatch": "^2.2.1"
       }
     },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
     "fastq": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.9.0.tgz",
@@ -287,6 +585,15 @@
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
+      }
+    },
+    "file-entry-cache": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+      "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^2.0.1"
       }
     },
     "fill-range": {
@@ -297,6 +604,34 @@
       "requires": {
         "to-regex-range": "^5.0.1"
       }
+    },
+    "flat-cache": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+      "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+      "dev": true,
+      "requires": {
+        "flatted": "^2.0.0",
+        "rimraf": "2.6.3",
+        "write": "1.0.3"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
+    },
+    "flatted": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
+      "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
+      "dev": true
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -310,6 +645,12 @@
       "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
       "dev": true,
       "optional": true
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
     },
     "glob": {
       "version": "7.1.6",
@@ -332,6 +673,15 @@
       "dev": true,
       "requires": {
         "is-glob": "^4.0.1"
+      }
+    },
+    "globals": {
+      "version": "12.4.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+      "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+      "dev": true,
+      "requires": {
+        "type-fest": "^0.8.1"
       }
     },
     "globby": {
@@ -358,6 +708,30 @@
       "version": "5.1.8",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
       "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+      "dev": true
+    },
+    "import-fresh": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.2.tgz",
+      "integrity": "sha512-cTPNrlvJT6twpYy+YmKUKrTSjWFs3bjYjAhCwm+z4EOCubZxAuO+hHpRN64TqjEaYSHs7tJAE0w1CKMGmsG/lw==",
+      "dev": true,
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+          "dev": true
+        }
+      }
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
     "inflight": {
@@ -391,6 +765,12 @@
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
       "dev": true
     },
+    "is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
+    },
     "is-glob": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
@@ -406,6 +786,12 @@
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true
     },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
     "joycon": {
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/joycon/-/joycon-2.2.5.tgz",
@@ -416,13 +802,50 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
+      "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
       "dev": true,
-      "optional": true
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
+    },
+    "levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      }
     },
     "lines-and-columns": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
       "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+      "dev": true
+    },
+    "lodash": {
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
       "dev": true
     },
     "merge2": {
@@ -450,6 +873,27 @@
         "brace-expansion": "^1.1.7"
       }
     },
+    "minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5"
+      }
+    },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
     "mz": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
@@ -460,6 +904,12 @@
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
       }
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
     },
     "node-modules-regexp": {
       "version": "1.0.0",
@@ -488,10 +938,39 @@
         "wrappy": "1"
       }
     },
+    "optionator": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+      "dev": true,
+      "requires": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.3"
+      }
+    },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0"
+      }
+    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true
     },
     "path-type": {
@@ -515,6 +994,24 @@
         "node-modules-regexp": "^1.0.0"
       }
     },
+    "prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true
+    },
+    "progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
+    },
     "readdirp": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
@@ -523,6 +1020,12 @@
       "requires": {
         "picomatch": "^2.2.1"
       }
+    },
+    "regexpp": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
+      "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
+      "dev": true
     },
     "resolve-from": {
       "version": "5.0.0",
@@ -569,10 +1072,117 @@
       "integrity": "sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw==",
       "dev": true
     },
+    "semver": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+      "dev": true
+    },
+    "shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^3.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true
+    },
     "slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true
+    },
+    "slice-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+      "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.0",
+        "astral-regex": "^1.0.0",
+        "is-fullwidth-code-point": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "dev": true
+        }
+      }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "string-width": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+      "dev": true,
+      "requires": {
+        "emoji-regex": "^7.0.1",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^5.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
+    },
+    "strip-ansi": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^5.0.0"
+      }
+    },
+    "strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
     },
     "sucrase": {
@@ -597,6 +1207,24 @@
       "requires": {
         "has-flag": "^4.0.0"
       }
+    },
+    "table": {
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
+      "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.10.2",
+        "lodash": "^4.17.14",
+        "slice-ansi": "^2.1.0",
+        "string-width": "^3.0.0"
+      }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
     },
     "thenify": {
       "version": "3.3.1",
@@ -649,10 +1277,55 @@
         "sucrase": "^3.16.0"
       }
     },
+    "type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "^1.2.1"
+      }
+    },
+    "type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true
+    },
     "typescript": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.5.tgz",
       "integrity": "sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==",
+      "dev": true
+    },
+    "uri-js": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
+      "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "v8-compile-cache": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz",
+      "integrity": "sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==",
+      "dev": true
+    },
+    "which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true
     },
     "wrappy": {
@@ -660,6 +1333,15 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
+    },
+    "write": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+      "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^0.5.1"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "prepublishOnly": "npm run build",
     "release": "npx bumpp --all --commit --tag && npm publish --access public && git push",
     "site": "node ./tools/make_site.js",
-    "examples": "node ./tools/compile_examples.js"
+    "examples": "node ./tools/compile_examples.js",
+    "lint": "eslint ./psvg.ts",
+    "format": "eslint --fix ./psvg.ts"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "homepage": "https://github.com/LingDong-/psvg#readme",
   "devDependencies": {
     "@types/node": "^14.14.8",
+    "eslint": "^7.14.0",
     "rimraf": "^3.0.2",
     "tsup": "^3.8.0",
     "typescript": "^4.0.5"

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@typescript-eslint/eslint-plugin": "^4.8.1",
     "@typescript-eslint/parser": "^4.8.1",
     "eslint": "^7.14.0",
+    "eslint-config-prettier": "^6.15.0",
     "prettier": "^2.2.0",
     "rimraf": "^3.0.2",
     "tsup": "^3.8.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "homepage": "https://github.com/LingDong-/psvg#readme",
   "devDependencies": {
     "@types/node": "^14.14.8",
+    "@typescript-eslint/eslint-plugin": "^4.8.1",
     "@typescript-eslint/parser": "^4.8.1",
     "eslint": "^7.14.0",
     "rimraf": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "homepage": "https://github.com/LingDong-/psvg#readme",
   "devDependencies": {
     "@types/node": "^14.14.8",
+    "@typescript-eslint/parser": "^4.8.1",
     "eslint": "^7.14.0",
     "rimraf": "^3.0.2",
     "tsup": "^3.8.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@typescript-eslint/parser": "^4.8.1",
     "eslint": "^7.14.0",
     "eslint-config-prettier": "^6.15.0",
+    "eslint-plugin-prettier": "^3.1.4",
     "prettier": "^2.2.0",
     "rimraf": "^3.0.2",
     "tsup": "^3.8.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@typescript-eslint/eslint-plugin": "^4.8.1",
     "@typescript-eslint/parser": "^4.8.1",
     "eslint": "^7.14.0",
+    "prettier": "^2.2.0",
     "rimraf": "^3.0.2",
     "tsup": "^3.8.0",
     "typescript": "^4.0.5"

--- a/psvg.ts
+++ b/psvg.ts
@@ -134,7 +134,7 @@ export function transpilePSVG(prgm:PSVGElement[]):string{
     if (hascm){
       x = x.replace(/, */g,',');
       const hasws = x['includes'](' ');
-      var y = __tolist(x);
+      const y = __tolist(x);
       if (!hasws){
         y['allCommas']=true;
       }
@@ -246,12 +246,12 @@ export function transpilePSVG(prgm:PSVGElement[]):string{
       // return '__val(`'+x.replace(/(?<!\\)\{/g,"${") + "`)";
       return '__val(`'+x.replace(/([^\\]|^)\{/g,'$1${') + "`)";
     }
-    for (var i = 0; i < prgm.length; i++){
+    for (let i = 0; i < prgm.length; i++){
       if (prgm[i].tagName.toUpperCase() == "PSVG"){
         const w = transpileValue(prgm[i].attributes.width??"100");
         const h = transpileValue(prgm[i].attributes.height??"100");
         out += `__out+=\`<svg xmlns="http://www.w3.org/2000/svg" width="\${${w}}" height="\${${h}}" `;
-        for (var k in prgm[i].attributes){
+        for (const k in prgm[i].attributes){
           if (!(["width","height","background"]['includes'](k))){
             out += `${k}="\${${transpileValue(prgm[i].attributes[k])}}" `
           }
@@ -271,7 +271,7 @@ export function transpilePSVG(prgm:PSVGElement[]):string{
         out += `};`;
       }else if (prgm[i].tagName.toUpperCase() == "IF"){
         if (Object.keys(prgm[i].attributes).length==0){
-          for (var j = 0; j < prgm[i].children.length; j++){
+          for (let j = 0; j < prgm[i].children.length; j++){
             if (j != 0){
               out += "else ";
             }
@@ -308,7 +308,7 @@ export function transpilePSVG(prgm:PSVGElement[]):string{
         groups++;
       }else if (prgm[i].tagName.toUpperCase() == "STROKE"){
         out += "__out+=`<g ";
-        for (var k in prgm[i].attributes){
+        for (const k in prgm[i].attributes){
           out += `${{
             color:"stroke",
             value:"stroke",
@@ -326,7 +326,7 @@ export function transpilePSVG(prgm:PSVGElement[]):string{
         groups++;
       }else if (prgm[i].tagName.toUpperCase() == "FILL"){
         out += "__out+=`<g ";
-        for (var k in prgm[i].attributes){
+        for (const k in prgm[i].attributes){
           out += `${{
             color:"fill",
             value:"fill",
@@ -338,7 +338,7 @@ export function transpilePSVG(prgm:PSVGElement[]):string{
         groups++;
       }else if (prgm[i].tagName.toUpperCase() == "FONT"){
         out += "__out+=`<g ";
-        for (var k in prgm[i].attributes){
+        for (const k in prgm[i].attributes){
           out += `${{
             family:"font-family",
             font:"font-family",
@@ -357,15 +357,15 @@ export function transpilePSVG(prgm:PSVGElement[]):string{
         out += `__out+=\`<g transform="scale(\${${transpileValue(prgm[i].attributes.x)}} \${${transpileValue(prgm[i].attributes.y)}})">\`;`
         groups++;
       }else if (prgm[i].tagName.toUpperCase() == "VAR"){
-        for (var k in prgm[i].attributes){
+        for (const k in prgm[i].attributes){
           out += `let ${k}=${transpileValue(prgm[i].attributes[k])};`
         }
       }else if (prgm[i].tagName.toUpperCase() == "ASGN" || prgm[i].tagName.toUpperCase() == "ASSIGN"){
-        for (var k in prgm[i].attributes){
+        for (const k in prgm[i].attributes){
           out += `${k}=${transpileValue(prgm[i].attributes[k])};`
         }
       }else if (prgm[i].tagName.toUpperCase() == "RETURN"){
-        for (var j = 0; j < groups; j++){
+        for (let j = 0; j < groups; j++){
           out += "__out+='</g>';"
         }
         if (prgm[i].attributes.value){
@@ -375,7 +375,7 @@ export function transpilePSVG(prgm:PSVGElement[]):string{
         }
       }else if (prgm[i].tagName.toUpperCase() == "FOR"){
         let name : string;
-        for (var k in prgm[i].attributes){
+        for (const k in prgm[i].attributes){
           
           if (!(["true","false","step"]['includes'](k))){
             name = k;
@@ -406,7 +406,7 @@ export function transpilePSVG(prgm:PSVGElement[]):string{
       }else if (prgm[i].tagName in funcs){
         out += prgm[i].tagName+"(";
         const args = funcs[prgm[i].tagName].args;
-        for (var j = 0; j < args.length; j++){
+        for (let j = 0; j < args.length; j++){
           const v = prgm[i].attributes[args[j]];
           out += v===undefined?"undefined":transpileValue(v);
           out += ",";
@@ -414,7 +414,7 @@ export function transpilePSVG(prgm:PSVGElement[]):string{
         out += ");"
       }else{
         out += "__out+=`<"+prgm[i].tagName+" ";
-        for (var k in prgm[i].attributes){
+        for (const k in prgm[i].attributes){
           out += `${k}="\${${transpileValue(prgm[i].attributes[k])}}" `;
         }
         const needInner = ["TEXT","STYLE"]['includes'](prgm[i].tagName.toUpperCase());
@@ -430,7 +430,7 @@ export function transpilePSVG(prgm:PSVGElement[]):string{
         }
       }
     }
-    for (var i = 0; i < groups; i++){
+    for (let i = 0; i < groups; i++){
       out += "__out+='</g>';"
     }
     return out;

--- a/psvg.ts
+++ b/psvg.ts
@@ -11,7 +11,7 @@ export interface PSVGFunc {
 
 export function parsePSVG(str:string) : PSVGElement[] {
   str = str.replace(/<!--[^\0]*?-->/gm,"");
-  let i : number = 0;
+  let i = 0;
   const elts : PSVGElement[]=[];
   while (i <= str.length){
     if (str[i] == "<"){
@@ -230,7 +230,7 @@ export function transpilePSVG(prgm:PSVGElement[]):string{
   
   function transpilePSVGList(prgm:PSVGElement[]):string{
 
-    let out : string = "";
+    let out = "";
     let groups = 0;
 
     function transpileValue(x:string):string{

--- a/psvg.ts
+++ b/psvg.ts
@@ -1,110 +1,117 @@
 export interface PSVGElement {
-  tagName:string;
-  children:PSVGElement[];
-  attributes:Record<string,string>;
-  innerHTML:string;
+  tagName: string;
+  children: PSVGElement[];
+  attributes: Record<string, string>;
+  innerHTML: string;
 }
 export interface PSVGFunc {
-  name:string;
-  args:string[];
+  name: string;
+  args: string[];
 }
 
-export function parsePSVG(str:string) : PSVGElement[] {
-  str = str.replace(/<!--[^\0]*?-->/gm,"");
+export function parsePSVG(str: string): PSVGElement[] {
+  str = str.replace(/<!--[^\0]*?-->/gm, '');
   let i = 0;
-  const elts : PSVGElement[]=[];
-  while (i <= str.length){
-    if (str[i] == "<"){
-      let j = i+1;
+  const elts: PSVGElement[] = [];
+  while (i <= str.length) {
+    if (str[i] == '<') {
+      let j = i + 1;
       let bodyStart = -1;
       let bodyEnd = -1;
       let quote = false;
       let lvl = 0;
 
-      const getTagName = (open: string) => open.trim().split(" ")[0].trimEnd();
+      const getTagName = (open: string) => open.trim().split(' ')[0].trimEnd();
 
       const getAttributes = (open: string) => {
-          // oneliner doesn't work for safari:
-          // return Object['fromEntries'](Array['from'](open.split(" ").slice(1).join(" ")['matchAll'](/(^| )([^ ]+?)\="([^"]*)"/g)).map((x:string)=>x.slice(2)));
+        // oneliner doesn't work for safari:
+        // return Object['fromEntries'](Array['from'](open.split(" ").slice(1).join(" ")['matchAll'](/(^| )([^ ]+?)\="([^"]*)"/g)).map((x:string)=>x.slice(2)));
 
-          // stupid polyfill for safari:
-          const attrsStr = open.split(" ").slice(1).join(" ");
+        // stupid polyfill for safari:
+        const attrsStr = open.split(' ').slice(1).join(' ');
 
-          const matchAll = attrsStr.matchAll ? (re:RegExp)=>attrsStr.matchAll(re) : ((re: RegExp) => {
-            const ms: RegExpMatchArray[] = [];
-            while (1) {
-              const m = re.exec(attrsStr);
-              if (m) ms.push(m);
-              else break;
-            }
-            return ms;
-          });
+        const matchAll = attrsStr.matchAll
+          ? (re: RegExp) => attrsStr.matchAll(re)
+          : (re: RegExp) => {
+              const ms: RegExpMatchArray[] = [];
+              while (1) {
+                const m = re.exec(attrsStr);
+                if (m) ms.push(m);
+                else break;
+              }
+              return ms;
+            };
 
-          const fromEntries = Object.fromEntries || ((a: any) => {
+        const fromEntries =
+          Object.fromEntries ||
+          ((a: any) => {
             const o = {};
-            a.map(([key, value]) => o[key] = value);
+            a.map(([key, value]) => (o[key] = value));
             return o;
           });
 
+        return fromEntries(
           // @ts-ignore
-          return fromEntries(Array['from'](matchAll(/(^| )([^ ]+?)\="([^"]*)"/g)).map((x:string)=>x.slice(2)));
+          // prettier-ignore
+          Array['from'](matchAll(/(^| )([^ ]+?)\="([^"]*)"/g)).map((x: string) => x.slice(2))
+        );
       };
 
       const parseNormalTag = (): void => {
         const open = str.slice(i + 1, bodyStart - 1);
         const body = str.slice(bodyStart, bodyEnd);
         const elt: PSVGElement = {
-            tagName: getTagName(open),
-            attributes: getAttributes(open),
-            children: parsePSVG(body),
-            innerHTML: body,
+          tagName: getTagName(open),
+          attributes: getAttributes(open),
+          children: parsePSVG(body),
+          innerHTML: body,
         };
         elts.push(elt);
-    };
+      };
 
-    const parseSelfClosingTag = (): void => {
+      const parseSelfClosingTag = (): void => {
         const open = str.slice(i + 1, j);
         const elt: PSVGElement = {
-            tagName: getTagName(open),
-            attributes: getAttributes(open),
-            children: [],
-            innerHTML: '',
+          tagName: getTagName(open),
+          attributes: getAttributes(open),
+          children: [],
+          innerHTML: '',
         };
         elts.push(elt);
-    };
+      };
 
-      while (j <= str.length){
-        if (str[j]=='\\'){
+      while (j <= str.length) {
+        if (str[j] == '\\') {
           j++;
         }
-        if (str[j]=='"'){
+        if (str[j] == '"') {
           quote = !quote;
         }
-        if (!quote){
-          if (str[j] == ">" && lvl == 0 && bodyStart == -1){
-            bodyStart = j+1;
+        if (!quote) {
+          if (str[j] == '>' && lvl == 0 && bodyStart == -1) {
+            bodyStart = j + 1;
           }
 
-          if (str[j] == "<"){
-            if (str[j+1] == "/"){
+          if (str[j] == '<') {
+            if (str[j + 1] == '/') {
               lvl--;
-              if (lvl == -1){
+              if (lvl == -1) {
                 bodyEnd = j;
               }
-              while(str[j] != ">"){
+              while (str[j] != '>') {
                 j++;
               }
-              if (lvl == -1){
+              if (lvl == -1) {
                 parseNormalTag();
                 i = j;
                 break;
               }
-            }else{
+            } else {
               lvl++;
             }
-          }else if (str[j] == "/" && str[j+1]==">"){
+          } else if (str[j] == '/' && str[j + 1] == '>') {
             lvl--;
-            if (lvl == -1){
+            if (lvl == -1) {
               parseSelfClosingTag();
               i = j;
               break;
@@ -119,329 +126,404 @@ export function parsePSVG(str:string) : PSVGElement[] {
   return elts;
 }
 
-
-export function transpilePSVG(prgm:PSVGElement[]):string{
-  const funcs : Record<string,PSVGFunc> = {};
-  function __val(x:string):any{
-    if (new RegExp(/^[+-]?(\d+([.]\d*)?([eE][+-]?\d+)?|[.]\d+([eE][+-]?\d+)?)$/g).test(x)){
+export function transpilePSVG(prgm: PSVGElement[]): string {
+  const funcs: Record<string, PSVGFunc> = {};
+  function __val(x: string): any {
+    if (
+      new RegExp(
+        /^[+-]?(\d+([.]\d*)?([eE][+-]?\d+)?|[.]\d+([eE][+-]?\d+)?)$/g
+      ).test(x)
+    ) {
       return parseFloat(x);
     }
-    if (x==`true` || x==`false`){
-      return x==`true`;
+    if (x == `true` || x == `false`) {
+      return x == `true`;
     }
-    
+
     const hascm = x['includes'](',');
-    if (hascm){
-      x = x.replace(/, */g,',');
+    if (hascm) {
+      x = x.replace(/, */g, ',');
       const hasws = x['includes'](' ');
       const y = __tolist(x);
-      if (!hasws){
-        y['allCommas']=true;
+      if (!hasws) {
+        y['allCommas'] = true;
       }
       return y;
     }
-    if (x['includes'](' ')){
+    if (x['includes'](' ')) {
       return __tolist(x);
     }
     return x;
   }
-  function __makelist(x:any[]):any[]{
-    x.toString = function(){return x.join(x['allCommas']?',':' ');};
+  function __makelist(x: any[]): any[] {
+    x.toString = function () {
+      return x.join(x['allCommas'] ? ',' : ' ');
+    };
     return x;
   }
-  function __tolist(s:string):any[]{
-    return __makelist(s.replace(/,/g,' ').split(" ").filter(x=>x.length).map(__val));
+  function __tolist(s: string): any[] {
+    return __makelist(
+      s
+        .replace(/,/g, ' ')
+        .split(' ')
+        .filter((x) => x.length)
+        .map(__val)
+    );
   }
 
-  const builtins : Record<string,string> = {
-    NTH:(function(x:any[]|string,i:number):any{
-      if (typeof x == 'string'){
+  const builtins: Record<string, string> = {
+    NTH: function (x: any[] | string, i: number): any {
+      if (typeof x == 'string') {
         x = __tolist(x);
       }
       return x[i];
-    }).toString(),
-    TAKE:(function(x:any[]|string,n:number):any[]{
-      if (typeof x == 'string'){
+    }.toString(),
+    TAKE: function (x: any[] | string, n: number): any[] {
+      if (typeof x == 'string') {
         x = __tolist(x);
       }
-      return __makelist(x.slice(0,n));
-    }).toString(),
-    DROP:(function(x:any[]|string,n:number):any[]{
-      if (typeof x == 'string'){
+      return __makelist(x.slice(0, n));
+    }.toString(),
+    DROP: function (x: any[] | string, n: number): any[] {
+      if (typeof x == 'string') {
         x = __tolist(x);
       }
       return __makelist(x.slice(n));
-    }).toString(),
-    UPDATE:(function(x:any[]|string,i:number,y:any):any[]{
-      if (typeof x == 'string'){
+    }.toString(),
+    UPDATE: function (x: any[] | string, i: number, y: any): any[] {
+      if (typeof x == 'string') {
         x = __tolist(x);
       }
       const z = x.slice();
-      z[i]=y;
+      z[i] = y;
       return __makelist(z);
-    }).toString(),
-    MAP:(function(x:any[]|string,f:(x:any)=>any):any[]{
-      if (typeof x == 'string'){
+    }.toString(),
+    MAP: function (x: any[] | string, f: (x: any) => any): any[] {
+      if (typeof x == 'string') {
         x = __tolist(x);
       }
-      return __makelist(x.map(y=>f(__val(y))));
-    }).toString(),
-    FILTER:(function(x:any[]|string,f:(x:any)=>any):any[]{
-      if (typeof x == 'string'){
+      return __makelist(x.map((y) => f(__val(y))));
+    }.toString(),
+    FILTER: function (x: any[] | string, f: (x: any) => any): any[] {
+      if (typeof x == 'string') {
         x = __tolist(x);
       }
-      return __makelist(x.filter(y=>f(__val(y))));
-    }).toString(),
-    COUNT:(function(x:any[]|string):number{
-      if (typeof x == 'string'){
+      return __makelist(x.filter((y) => f(__val(y))));
+    }.toString(),
+    COUNT: function (x: any[] | string): number {
+      if (typeof x == 'string') {
         x = __tolist(x);
       }
       return x.length;
-    }).toString(),
-    CAT:(function(...args:any):any[]{
-      return __makelist([].concat(...args.filter((y:any)=>y.toString().length).map(
-        (x:any)=>(typeof x=='string')?__tolist(x):x
-      )));
-    }).toString(),
-    REV:(function(x:any[]|string):any[]{
-      if (typeof x == 'string'){
+    }.toString(),
+    CAT: function (...args: any): any[] {
+      return __makelist(
+        [].concat(
+          ...args
+            .filter((y: any) => y.toString().length)
+            .map((x: any) => (typeof x == 'string' ? __tolist(x) : x))
+        )
+      );
+    }.toString(),
+    REV: function (x: any[] | string): any[] {
+      if (typeof x == 'string') {
         x = __tolist(x);
       }
       return __makelist(x.slice().reverse());
-    }).toString(),
-    FILL:(function(x:any,n:number):any[]{
+    }.toString(),
+    FILL: function (x: any, n: number): any[] {
       return __makelist(new Array(n)['fill'](x));
-    }).toString(),
+    }.toString(),
 
-    LERP:(function(x:number,y:number,t:number):number{
-      return x*(1-t)+y*t;
-    }).toString(),
-    CLAMP:(function(x:number,lo:number,hi:number):number{
-      [lo,hi]=[Math.min(lo,hi),Math.max(lo,hi)];
-      return Math.min(Math.max(x,lo),hi);
-    }).toString(),
-    MAPVAL:(function(x:number,istart:number,istop:number,ostart:number,ostop:number):number{
+    LERP: function (x: number, y: number, t: number): number {
+      return x * (1 - t) + y * t;
+    }.toString(),
+    CLAMP: function (x: number, lo: number, hi: number): number {
+      [lo, hi] = [Math.min(lo, hi), Math.max(lo, hi)];
+      return Math.min(Math.max(x, lo), hi);
+    }.toString(),
+    MAPVAL: function (
+      x: number,
+      istart: number,
+      istop: number,
+      ostart: number,
+      ostop: number
+    ): number {
       return ostart + (ostop - ostart) * ((x - istart) / (istop - istart));
-    }).toString(),
-  }
-  Object.getOwnPropertyNames(Math).map(x=>builtins[x.toUpperCase()]=`Math["${x}"]`);
+    }.toString(),
+  };
+  Object.getOwnPropertyNames(Math).map(
+    (x) => (builtins[x.toUpperCase()] = `Math["${x}"]`)
+  );
 
-  return __val.toString()+";"+__tolist.toString()+";"+__makelist.toString()+";"+Object['entries'](builtins).map((x:string[])=>"const "+x[0]+"="+x[1]).join(";")+";let __out='';"+transpilePSVGList(prgm)+";"+"__out;";
-  
-  function transpilePSVGList(prgm:PSVGElement[]):string{
+  return (
+    __val.toString() +
+    ';' +
+    __tolist.toString() +
+    ';' +
+    __makelist.toString() +
+    ';' +
+    Object['entries'](builtins)
+      .map((x: string[]) => 'const ' + x[0] + '=' + x[1])
+      .join(';') +
+    ";let __out='';" +
+    transpilePSVGList(prgm) +
+    ';' +
+    '__out;'
+  );
 
-    let out = "";
+  function transpilePSVGList(prgm: PSVGElement[]): string {
+    let out = '';
     let groups = 0;
 
-    function transpileValue(x:string):string{
+    function transpileValue(x: string): string {
       x = x.trim();
-      x = x.replace(/&gt;/g,">").replace(/&lt;/g,"<").replace(/&amp;/g,"&").replace(/&quot;/g,'"');
-      if (x['startsWith']("{") && x['endsWith']("}") && (x.match(/{|}/g) || []).length==2){
-        return x.slice(1,-1);
+      x = x
+        .replace(/&gt;/g, '>')
+        .replace(/&lt;/g, '<')
+        .replace(/&amp;/g, '&')
+        .replace(/&quot;/g, '"');
+      if (
+        x['startsWith']('{') &&
+        x['endsWith']('}') &&
+        (x.match(/{|}/g) || []).length == 2
+      ) {
+        return x.slice(1, -1);
       }
-      if (new RegExp(/^[+-]?(\d+([.]\d*)?([eE][+-]?\d+)?|[.]\d+([eE][+-]?\d+)?)$/g).test(x)){
+      if (
+        new RegExp(
+          /^[+-]?(\d+([.]\d*)?([eE][+-]?\d+)?|[.]\d+([eE][+-]?\d+)?)$/g
+        ).test(x)
+      ) {
         return x;
       }
       // crappy safari doesn't support lookbehind yet
       // return '__val(`'+x.replace(/(?<!\\)\{/g,"${") + "`)";
-      return '__val(`'+x.replace(/([^\\]|^)\{/g,'$1${') + "`)";
+      return '__val(`' + x.replace(/([^\\]|^)\{/g, '$1${') + '`)';
     }
-    for (let i = 0; i < prgm.length; i++){
-      if (prgm[i].tagName.toUpperCase() == "PSVG"){
-        const w = transpileValue(prgm[i].attributes.width??"100");
-        const h = transpileValue(prgm[i].attributes.height??"100");
+    for (let i = 0; i < prgm.length; i++) {
+      if (prgm[i].tagName.toUpperCase() == 'PSVG') {
+        const w = transpileValue(prgm[i].attributes.width ?? '100');
+        const h = transpileValue(prgm[i].attributes.height ?? '100');
         out += `__out+=\`<svg xmlns="http://www.w3.org/2000/svg" width="\${${w}}" height="\${${h}}" `;
-        for (const k in prgm[i].attributes){
-          if (!(["width","height","background"]['includes'](k))){
-            out += `${k}="\${${transpileValue(prgm[i].attributes[k])}}" `
+        for (const k in prgm[i].attributes) {
+          if (!['width', 'height', 'background']['includes'](k)) {
+            out += `${k}="\${${transpileValue(prgm[i].attributes[k])}}" `;
           }
         }
-        out += ">`;";
+        out += '>`;';
         out += `const WIDTH=${w};const HEIGHT=${h};`;
-        if (prgm[i].attributes.background){
-          out += `__out+=\`<rect x="0" y="0" width="\${${w}}" height="\${${h}}" fill="\${${transpileValue(prgm[i].attributes.background)}}"/>\`;`
+        if (prgm[i].attributes.background) {
+          out += `__out+=\`<rect x="0" y="0" width="\${${w}}" height="\${${h}}" fill="\${${transpileValue(
+            prgm[i].attributes.background
+          )}}"/>\`;`;
         }
         out += transpilePSVGList(prgm[i].children);
         out += `__out+='</svg>';`;
-      }else if (prgm[i].tagName.toUpperCase()['startsWith']("DEF-")){
-        const name = prgm[i].tagName.split("-").slice(1).join("-");
-        funcs[name]={name,args:Object.keys(prgm[i].attributes)};
-        out += `function ${name}(${Object['entries'](prgm[i].attributes).map((x:string[])=>x[0]+"="+transpileValue(x[1]))}){`;
+      } else if (prgm[i].tagName.toUpperCase()['startsWith']('DEF-')) {
+        const name = prgm[i].tagName.split('-').slice(1).join('-');
+        funcs[name] = { name, args: Object.keys(prgm[i].attributes) };
+        out += `function ${name}(${Object['entries'](prgm[i].attributes).map(
+          (x: string[]) => x[0] + '=' + transpileValue(x[1])
+        )}){`;
         out += transpilePSVGList(prgm[i].children);
         out += `};`;
-      }else if (prgm[i].tagName.toUpperCase() == "IF"){
-        if (Object.keys(prgm[i].attributes).length==0){
-          for (let j = 0; j < prgm[i].children.length; j++){
-            if (j != 0){
-              out += "else ";
+      } else if (prgm[i].tagName.toUpperCase() == 'IF') {
+        if (Object.keys(prgm[i].attributes).length == 0) {
+          for (let j = 0; j < prgm[i].children.length; j++) {
+            if (j != 0) {
+              out += 'else ';
             }
-            if (prgm[i].children[j].attributes.true){
-              out += `if (${transpileValue(prgm[i].children[j].attributes.true)})`;
-            }else if (prgm[i].children[j].attributes.false){
-              out += `if (!(${transpileValue(prgm[i].children[j].attributes.false)}))`;
+            if (prgm[i].children[j].attributes.true) {
+              out += `if (${transpileValue(
+                prgm[i].children[j].attributes.true
+              )})`;
+            } else if (prgm[i].children[j].attributes.false) {
+              out += `if (!(${transpileValue(
+                prgm[i].children[j].attributes.false
+              )}))`;
             }
-            out += "{";
+            out += '{';
             out += transpilePSVGList(prgm[i].children[j].children);
-            out += "}"
+            out += '}';
           }
-          out += ";";
-        }else{
-          if (prgm[i].attributes.true){
+          out += ';';
+        } else {
+          if (prgm[i].attributes.true) {
             out += `if (${transpileValue(prgm[i].attributes.true)}){`;
-          }else if (prgm[i].attributes.false){
+          } else if (prgm[i].attributes.false) {
             out += `if (!(${transpileValue(prgm[i].attributes.false)})){`;
           }
           out += transpilePSVGList(prgm[i].children);
-          out += "};"
+          out += '};';
         }
-      }else if (prgm[i].tagName.toUpperCase() == "PUSH"){
+      } else if (prgm[i].tagName.toUpperCase() == 'PUSH') {
         out += transpilePSVGList(prgm[i].children);
-      }else if (prgm[i].tagName.toUpperCase() == "TRANSLATE"){
-        out += `__out+=\`<g transform="translate(\${${transpileValue(prgm[i].attributes.x)}} \${${transpileValue(prgm[i].attributes.y)}})">\`;`
+      } else if (prgm[i].tagName.toUpperCase() == 'TRANSLATE') {
+        out += `__out+=\`<g transform="translate(\${${transpileValue(
+          prgm[i].attributes.x
+        )}} \${${transpileValue(prgm[i].attributes.y)}})">\`;`;
         groups++;
-      }else if (prgm[i].tagName.toUpperCase() == "ROTATE"){
-        if (prgm[i].attributes.rad){
-          out += `__out+=\`<g transform="rotate(\${(${transpileValue(prgm[i].attributes.rad)})*180/Math.PI})">\`;`
-        }else{
-          out += `__out+=\`<g transform="rotate(\${${transpileValue(prgm[i].attributes.deg)}})">\`;`
+      } else if (prgm[i].tagName.toUpperCase() == 'ROTATE') {
+        if (prgm[i].attributes.rad) {
+          out += `__out+=\`<g transform="rotate(\${(${transpileValue(
+            prgm[i].attributes.rad
+          )})*180/Math.PI})">\`;`;
+        } else {
+          out += `__out+=\`<g transform="rotate(\${${transpileValue(
+            prgm[i].attributes.deg
+          )}})">\`;`;
         }
         groups++;
-      }else if (prgm[i].tagName.toUpperCase() == "STROKE"){
-        out += "__out+=`<g ";
-        for (const k in prgm[i].attributes){
-          out += `${{
-            color:"stroke",
-            value:"stroke",
-            width:"stroke-width",
-            weight:"stroke-width",
-            opacity:"stroke-opacity",
-            cap:"stroke-linecap",
-            join:"stroke-linejoin",
-            dash:"stroke-dasharray",
-            dashoffset:"stroke-dashoffset",
-            miterlimit:"stroke-miterlimit",
-          }[k]}="\${${transpileValue(prgm[i].attributes[k])}}" `
+      } else if (prgm[i].tagName.toUpperCase() == 'STROKE') {
+        out += '__out+=`<g ';
+        for (const k in prgm[i].attributes) {
+          out += `${
+            {
+              color: 'stroke',
+              value: 'stroke',
+              width: 'stroke-width',
+              weight: 'stroke-width',
+              opacity: 'stroke-opacity',
+              cap: 'stroke-linecap',
+              join: 'stroke-linejoin',
+              dash: 'stroke-dasharray',
+              dashoffset: 'stroke-dashoffset',
+              miterlimit: 'stroke-miterlimit',
+            }[k]
+          }="\${${transpileValue(prgm[i].attributes[k])}}" `;
         }
-        out += ">`;";
+        out += '>`;';
         groups++;
-      }else if (prgm[i].tagName.toUpperCase() == "FILL"){
-        out += "__out+=`<g ";
-        for (const k in prgm[i].attributes){
-          out += `${{
-            color:"fill",
-            value:"fill",
-            opacity:"fill-opacity",
-            rule:"fill-rule",
-          }[k]}="\${${transpileValue(prgm[i].attributes[k])}}" `
+      } else if (prgm[i].tagName.toUpperCase() == 'FILL') {
+        out += '__out+=`<g ';
+        for (const k in prgm[i].attributes) {
+          out += `${
+            {
+              color: 'fill',
+              value: 'fill',
+              opacity: 'fill-opacity',
+              rule: 'fill-rule',
+            }[k]
+          }="\${${transpileValue(prgm[i].attributes[k])}}" `;
         }
-        out += ">`;";
+        out += '>`;';
         groups++;
-      }else if (prgm[i].tagName.toUpperCase() == "FONT"){
-        out += "__out+=`<g ";
-        for (const k in prgm[i].attributes){
-          out += `${{
-            family:"font-family",
-            font:"font-family",
-            style:"font-style",
-            variant:"font-variant",
-            stretch:"font-stretch",
-            size:"font-size",
-            anchor:"text-anchor",
-            weight:"font-weight",
-            decoration:"text-decoration",
-          }[k]}="\${${transpileValue(prgm[i].attributes[k])}}" `
+      } else if (prgm[i].tagName.toUpperCase() == 'FONT') {
+        out += '__out+=`<g ';
+        for (const k in prgm[i].attributes) {
+          out += `${
+            {
+              family: 'font-family',
+              font: 'font-family',
+              style: 'font-style',
+              variant: 'font-variant',
+              stretch: 'font-stretch',
+              size: 'font-size',
+              anchor: 'text-anchor',
+              weight: 'font-weight',
+              decoration: 'text-decoration',
+            }[k]
+          }="\${${transpileValue(prgm[i].attributes[k])}}" `;
         }
-        out += ">`;";
+        out += '>`;';
         groups++;
-      }else if (prgm[i].tagName.toUpperCase() == "SCALE"){
-        out += `__out+=\`<g transform="scale(\${${transpileValue(prgm[i].attributes.x)}} \${${transpileValue(prgm[i].attributes.y)}})">\`;`
+      } else if (prgm[i].tagName.toUpperCase() == 'SCALE') {
+        out += `__out+=\`<g transform="scale(\${${transpileValue(
+          prgm[i].attributes.x
+        )}} \${${transpileValue(prgm[i].attributes.y)}})">\`;`;
         groups++;
-      }else if (prgm[i].tagName.toUpperCase() == "VAR"){
-        for (const k in prgm[i].attributes){
-          out += `let ${k}=${transpileValue(prgm[i].attributes[k])};`
+      } else if (prgm[i].tagName.toUpperCase() == 'VAR') {
+        for (const k in prgm[i].attributes) {
+          out += `let ${k}=${transpileValue(prgm[i].attributes[k])};`;
         }
-      }else if (prgm[i].tagName.toUpperCase() == "ASGN" || prgm[i].tagName.toUpperCase() == "ASSIGN"){
-        for (const k in prgm[i].attributes){
-          out += `${k}=${transpileValue(prgm[i].attributes[k])};`
+      } else if (
+        prgm[i].tagName.toUpperCase() == 'ASGN' ||
+        prgm[i].tagName.toUpperCase() == 'ASSIGN'
+      ) {
+        for (const k in prgm[i].attributes) {
+          out += `${k}=${transpileValue(prgm[i].attributes[k])};`;
         }
-      }else if (prgm[i].tagName.toUpperCase() == "RETURN"){
-        for (let j = 0; j < groups; j++){
-          out += "__out+='</g>';"
+      } else if (prgm[i].tagName.toUpperCase() == 'RETURN') {
+        for (let j = 0; j < groups; j++) {
+          out += "__out+='</g>';";
         }
-        if (prgm[i].attributes.value){
+        if (prgm[i].attributes.value) {
           out += `return ${transpileValue(prgm[i].attributes.value)};`;
-        }else{
+        } else {
           out += `return;`;
         }
-      }else if (prgm[i].tagName.toUpperCase() == "FOR"){
-        let name : string;
-        for (const k in prgm[i].attributes){
-          
-          if (!(["true","false","step"]['includes'](k))){
+      } else if (prgm[i].tagName.toUpperCase() == 'FOR') {
+        let name: string;
+        for (const k in prgm[i].attributes) {
+          if (!['true', 'false', 'step']['includes'](k)) {
             name = k;
             break;
           }
         }
-        const step : string = prgm[i].attributes['step']??"1";
+        const step: string = prgm[i].attributes['step'] ?? '1';
 
         out += `for (let ${name}=${transpileValue(prgm[i].attributes[name])};`;
-        if (prgm[i].attributes.true){
+        if (prgm[i].attributes.true) {
           out += `${transpileValue(prgm[i].attributes.true)};`;
-        }else{
+        } else {
           out += `!(${transpileValue(prgm[i].attributes.false)});`;
         }
-        out += `${name}+=${transpileValue(step)}){`
+        out += `${name}+=${transpileValue(step)}){`;
         out += transpilePSVGList(prgm[i].children);
-        out += "};";
-
-      }else if (prgm[i].tagName.toUpperCase() == "WHILE"){
-        if (prgm[i].attributes.true){
+        out += '};';
+      } else if (prgm[i].tagName.toUpperCase() == 'WHILE') {
+        if (prgm[i].attributes.true) {
           out += `while (${transpileValue(prgm[i].attributes.true)}){`;
-        }else{
+        } else {
           out += `while (!(${transpileValue(prgm[i].attributes.false)})){`;
         }
         out += transpilePSVGList(prgm[i].children);
-        out += "};";
-
-      }else if (prgm[i].tagName in funcs){
-        out += prgm[i].tagName+"(";
+        out += '};';
+      } else if (prgm[i].tagName in funcs) {
+        out += prgm[i].tagName + '(';
         const args = funcs[prgm[i].tagName].args;
-        for (let j = 0; j < args.length; j++){
+        for (let j = 0; j < args.length; j++) {
           const v = prgm[i].attributes[args[j]];
-          out += v===undefined?"undefined":transpileValue(v);
-          out += ",";
+          out += v === undefined ? 'undefined' : transpileValue(v);
+          out += ',';
         }
-        out += ");"
-      }else{
-        out += "__out+=`<"+prgm[i].tagName+" ";
-        for (const k in prgm[i].attributes){
+        out += ');';
+      } else {
+        out += '__out+=`<' + prgm[i].tagName + ' ';
+        for (const k in prgm[i].attributes) {
           out += `${k}="\${${transpileValue(prgm[i].attributes[k])}}" `;
         }
-        const needInner = ["TEXT","STYLE"]['includes'](prgm[i].tagName.toUpperCase());
-        if (prgm[i].children.length || needInner){
-          out += ">`;";
+        const needInner = ['TEXT', 'STYLE']['includes'](
+          prgm[i].tagName.toUpperCase()
+        );
+        if (prgm[i].children.length || needInner) {
+          out += '>`;';
           out += transpilePSVGList(prgm[i].children);
-          if (needInner){
-            out += "__out+=`"+prgm[i].innerHTML.replace(/`/g,"/`").replace(/<.*?>/g,"")+"`;";
+          if (needInner) {
+            out +=
+              '__out+=`' +
+              prgm[i].innerHTML.replace(/`/g, '/`').replace(/<.*?>/g, '') +
+              '`;';
           }
-          out += "__out+='</"+prgm[i].tagName+">';";
-        }else{
-          out += "/>`;";
+          out += "__out+='</" + prgm[i].tagName + ">';";
+        } else {
+          out += '/>`;';
         }
       }
     }
-    for (let i = 0; i < groups; i++){
-      out += "__out+='</g>';"
+    for (let i = 0; i < groups; i++) {
+      out += "__out+='</g>';";
     }
     return out;
   }
 }
 
-export function evalPSVG(js:string):string {
+export function evalPSVG(js: string): string {
   return Function(`"use strict";${js};return __out;`)();
 }
 
-export function compilePSVG(psvg:string):string {
+export function compilePSVG(psvg: string): string {
   const prgm = parsePSVG(psvg);
   // console.dir(prgm,{depth:null});
   const js = transpilePSVG(prgm);
@@ -450,10 +532,10 @@ export function compilePSVG(psvg:string):string {
 }
 
 if (typeof window !== 'undefined') {
-  window.addEventListener('load',function(){
-    const psvgs = document.getElementsByTagName("PSVG");
-    for (let i = 0; i < psvgs.length; i++){
+  window.addEventListener('load', function () {
+    const psvgs = document.getElementsByTagName('PSVG');
+    for (let i = 0; i < psvgs.length; i++) {
       psvgs[i].outerHTML = compilePSVG(psvgs[i].outerHTML);
     }
-  })
+  });
 }

--- a/psvg.ts
+++ b/psvg.ts
@@ -121,7 +121,7 @@ export function parsePSVG(str:string) : PSVGElement[] {
 
 
 export function transpilePSVG(prgm:PSVGElement[]):string{
-  let funcs : Record<string,PSVGFunc> = {};
+  const funcs : Record<string,PSVGFunc> = {};
   function __val(x:string):any{
     if (new RegExp(/^[+-]?(\d+([.]\d*)?([eE][+-]?\d+)?|[.]\d+([eE][+-]?\d+)?)$/g).test(x)){
       return parseFloat(x);
@@ -130,10 +130,10 @@ export function transpilePSVG(prgm:PSVGElement[]):string{
       return x==`true`;
     }
     
-    let hascm = x['includes'](',');
+    const hascm = x['includes'](',');
     if (hascm){
       x = x.replace(/, */g,',');
-      let hasws = x['includes'](' ');
+      const hasws = x['includes'](' ');
       var y = __tolist(x);
       if (!hasws){
         y['allCommas']=true;
@@ -153,7 +153,7 @@ export function transpilePSVG(prgm:PSVGElement[]):string{
     return __makelist(s.replace(/,/g,' ').split(" ").filter(x=>x.length).map(__val));
   }
 
-  let builtins : Record<string,string> = {
+  const builtins : Record<string,string> = {
     NTH:(function(x:any[]|string,i:number):any{
       if (typeof x == 'string'){
         x = __tolist(x);
@@ -176,7 +176,7 @@ export function transpilePSVG(prgm:PSVGElement[]):string{
       if (typeof x == 'string'){
         x = __tolist(x);
       }
-      let z = x.slice();
+      const z = x.slice();
       z[i]=y;
       return __makelist(z);
     }).toString(),
@@ -248,8 +248,8 @@ export function transpilePSVG(prgm:PSVGElement[]):string{
     }
     for (var i = 0; i < prgm.length; i++){
       if (prgm[i].tagName.toUpperCase() == "PSVG"){
-        let w = transpileValue(prgm[i].attributes.width??"100");
-        let h = transpileValue(prgm[i].attributes.height??"100");
+        const w = transpileValue(prgm[i].attributes.width??"100");
+        const h = transpileValue(prgm[i].attributes.height??"100");
         out += `__out+=\`<svg xmlns="http://www.w3.org/2000/svg" width="\${${w}}" height="\${${h}}" `;
         for (var k in prgm[i].attributes){
           if (!(["width","height","background"]['includes'](k))){
@@ -264,7 +264,7 @@ export function transpilePSVG(prgm:PSVGElement[]):string{
         out += transpilePSVGList(prgm[i].children);
         out += `__out+='</svg>';`;
       }else if (prgm[i].tagName.toUpperCase()['startsWith']("DEF-")){
-        let name = prgm[i].tagName.split("-").slice(1).join("-");
+        const name = prgm[i].tagName.split("-").slice(1).join("-");
         funcs[name]={name,args:Object.keys(prgm[i].attributes)};
         out += `function ${name}(${Object['entries'](prgm[i].attributes).map((x:string[])=>x[0]+"="+transpileValue(x[1]))}){`;
         out += transpilePSVGList(prgm[i].children);
@@ -382,7 +382,7 @@ export function transpilePSVG(prgm:PSVGElement[]):string{
             break;
           }
         }
-        let step : string = prgm[i].attributes['step']??"1";
+        const step : string = prgm[i].attributes['step']??"1";
 
         out += `for (let ${name}=${transpileValue(prgm[i].attributes[name])};`;
         if (prgm[i].attributes.true){
@@ -405,9 +405,9 @@ export function transpilePSVG(prgm:PSVGElement[]):string{
 
       }else if (prgm[i].tagName in funcs){
         out += prgm[i].tagName+"(";
-        let args = funcs[prgm[i].tagName].args;
+        const args = funcs[prgm[i].tagName].args;
         for (var j = 0; j < args.length; j++){
-          let v = prgm[i].attributes[args[j]];
+          const v = prgm[i].attributes[args[j]];
           out += v===undefined?"undefined":transpileValue(v);
           out += ",";
         }
@@ -417,7 +417,7 @@ export function transpilePSVG(prgm:PSVGElement[]):string{
         for (var k in prgm[i].attributes){
           out += `${k}="\${${transpileValue(prgm[i].attributes[k])}}" `;
         }
-        let needInner = ["TEXT","STYLE"]['includes'](prgm[i].tagName.toUpperCase());
+        const needInner = ["TEXT","STYLE"]['includes'](prgm[i].tagName.toUpperCase());
         if (prgm[i].children.length || needInner){
           out += ">`;";
           out += transpilePSVGList(prgm[i].children);
@@ -442,9 +442,9 @@ export function evalPSVG(js:string):string {
 }
 
 export function compilePSVG(psvg:string):string {
-  let prgm = parsePSVG(psvg);
+  const prgm = parsePSVG(psvg);
   // console.dir(prgm,{depth:null});
-  let js = transpilePSVG(prgm);
+  const js = transpilePSVG(prgm);
   // console.log(js);
   return evalPSVG(js);
 }


### PR DESCRIPTION
Fixes: #14 

## Summary

- Install packages
  - `eslint` (Linter for ECMAScript)
  - `@typescript-eslint/parser` (Alternative ESLint parser for TypeScript)
  - `@typescript-eslint/eslint-plugin` (ESLint plugin for adding TypeScript-related rules)
  - `prettier` (Code formatter for various languages, including JavaScript)
  - `eslint-config-prettier` (Turns off all rules that are unnecessary or might conflict with Prettier)
  - `eslint-plugin-prettier` (Runs Prettier as an ESLint rule and reports differences as individual ESLint issues)
- Add configuraton files
  - `/.eslintrc.js`
  - `/.prettierrc.js`
- Add npm scripts
  - `lint` (Runs ESLint without changing code)
  - `format` (Runs ESLint and fixes issues automatically with overwriting code)
- Run the `format` script, then fix code manually for reducing ESLint issues

## Screenshots

Result of executing `npm run lint` command:

![Screenshot from 2020-11-21 16-18-09](https://user-images.githubusercontent.com/8453302/99870263-30d2f880-2c15-11eb-8c33-4daad61d84ed.png)

VS Code + ESLint extension:

![Screenshot from 2020-11-21 16-16-39](https://user-images.githubusercontent.com/8453302/99870267-33355280-2c15-11eb-8623-8f97726bd949.png)
